### PR TITLE
shamu: Add sepolicy for system_server to access kcal node

### DIFF
--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -8,3 +8,5 @@ unix_socket_send(system_server, mpdecision, mpdecision)
 
 unix_socket_connect(system_server, sensors, sensors)
 allow system_server sensors_socket:sock_file r_file_perms;
+
+allow system_server sysfs_display:file rw_file_perms;


### PR DESCRIPTION
 * This is used by LiveDisplay from the framework

Change-Id: I268e00b270eae22adc40f364ddb760aaa26241ef